### PR TITLE
Modify TinySDF to return only alpha channel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+yarn.lock

--- a/README.md
+++ b/README.md
@@ -16,7 +16,13 @@ Create a TinySDF for drawing SDFs based on font parameters:
     var cutoff = 0.25  // Across the board alpha channel reduction
                        // Reduces low-alpha pixels to zero, "thins" SDF overall
 
-    var fontFamily = 'sans-serif'; // css font-family to use
-    var tinySDFGenerator = new TinySDF(fontsize, buffer, radius, cutoff, fontFamily);
+    var fontFamily = 'sans-serif'; // css font-family
+    var fontWeight = 'normal';     // css font-weight
+    var tinySDFGenerator = new TinySDF(fontsize,
+                                       buffer,
+                                       radius,
+                                       cutoff,
+                                       fontFamily,
+                                       fontWeight);
 
     var oneSDF = tinySDFGenerator.draw('泽');

--- a/README.md
+++ b/README.md
@@ -6,3 +6,17 @@ from system fonts on the browser using Canvas 2D and
 This is very useful for [rendering text with WebGL](https://www.mapbox.com/blog/text-signed-distance-fields/).
 
 Demo: http://mapbox.github.io/tiny-sdf/
+
+## Usage
+Create a TinySDF for drawing SDFs based on font parameters:
+
+    var fontsize = 24; // Pixel font size
+    var buffer = 3;    // Pixel whitespace buffer around glyph
+    var radius = 8;    // Lower = "sharper", higher = "fuzzier"
+    var cutoff = 0.25  // Across the board alpha channel reduction
+                       // Reduces low-alpha pixels to zero, "thins" SDF overall
+
+    var fontFamily = 'sans-serif'; // css font-family to use
+    var tinySDFGenerator = new TinySDF(fontsize, buffer, radius, cutoff, fontFamily);
+
+    var oneSDF = tinySDFGenerator.draw('泽');

--- a/index.html
+++ b/index.html
@@ -18,6 +18,7 @@ a { color: #0af; }
     <h1><a href="https://github.com/mapbox/tiny-sdf">TinySDF</a> demo</h1>
     <p>
         <label>Font size</label> <input id="fontsize" type="range" min="16" max="104" step="8" value="24">
+        <label>Font weight</label> <input id="fontweight" type="range" min="100" max="900" step="100" value="400">
     </p>
     <canvas id="canvas" width="1000" height="400"></canvas>
     <p id="log"></p>
@@ -95,9 +96,10 @@ function makeRGBAImageData(alphaChannel, size) {
 function updateSDF() {
     ctx.clearRect(0, 0, canvas.width, canvas.height);
     var fontSize = +getEl('fontsize').value;
+    var fontWeight = +getEl('fontweight').value;
     var buffer = fontSize / 8;
     var radius = fontSize / 3;
-    var sdf = new TinySDF(fontSize, buffer, radius);
+    var sdf = new TinySDF(fontSize, buffer, radius, null, null, fontWeight);
 
     var now = performance.now();
     for (var y = 0, i = 0; y + sdf.size <= canvas.height && i < chars.length; y += sdf.size) {
@@ -107,7 +109,7 @@ function updateSDF() {
             i++;
         }
     }
-    getEl('log').innerHTML = i + ' characters (' + fontSize + 'px with ' + buffer + 'px buffer) rendered in ' + Math.round(performance.now() - now) + 'ms.';
+    getEl('log').innerHTML = i + ' characters (' + fontSize + 'px, font-weight: ' + fontWeight + ' with ' + buffer + 'px buffer) rendered in ' + Math.round(performance.now() - now) + 'ms.';
 }
 
 var canvas2 = document.getElementById('canvas2');
@@ -236,6 +238,7 @@ function drawGL() {
 }
 
 getEl('fontsize').oninput = frame;
+getEl('fontweight').oninput = frame;
 
 getEl('scale').oninput = drawGL;
 getEl('halo').oninput = drawGL;

--- a/index.html
+++ b/index.html
@@ -78,6 +78,20 @@ function getEl(id) {
     return document.getElementById(id);
 }
 
+// Convert alpha-only to RGBA so we can use convenient
+// `putImageData` for building the composite bitmap
+function makeRGBAImageData(alphaChannel, size) {
+    var imageData = ctx.createImageData(size, size);
+    var data = imageData.data;
+    for (var i = 0; i < alphaChannel.length; i++) {
+        data[4 * i + 0] = alphaChannel[i];
+        data[4 * i + 1] = alphaChannel[i];
+        data[4 * i + 2] = alphaChannel[i];
+        data[4 * i + 3] = 255;
+    }
+    return imageData;
+}
+
 function updateSDF() {
     ctx.clearRect(0, 0, canvas.width, canvas.height);
     var fontSize = +getEl('fontsize').value;
@@ -88,7 +102,7 @@ function updateSDF() {
     var now = performance.now();
     for (var y = 0, i = 0; y + sdf.size <= canvas.height && i < chars.length; y += sdf.size) {
         for (var x = 0; x + sdf.size <= canvas.width && i < chars.length; x += sdf.size) {
-            ctx.putImageData(sdf.draw(chars[i]), x, y);
+            ctx.putImageData(makeRGBAImageData(sdf.draw(chars[i]), sdf.size), x, y);
             sdfs[chars[i]] = {x: x, y: y};
             i++;
         }

--- a/index.js
+++ b/index.js
@@ -37,10 +37,10 @@ TinySDF.prototype.draw = function (char) {
     this.ctx.fillText(char, this.buffer, this.middle);
 
     var imgData = this.ctx.getImageData(0, 0, this.size, this.size);
-    var data = imgData.data;
+    var alphaChannel = new Uint8ClampedArray(this.size * this.size);
 
     for (var i = 0; i < this.size * this.size; i++) {
-        var a = data[i * 4 + 3] / 255; // alpha value
+        var a = imgData.data[i * 4 + 3] / 255; // alpha value
         this.gridOuter[i] = a === 1 ? 0 : a === 0 ? INF : Math.pow(Math.max(0, 0.5 - a), 2);
         this.gridInner[i] = a === 1 ? INF : a === 0 ? 0 : Math.pow(Math.max(0, a - 0.5), 2);
     }
@@ -50,14 +50,10 @@ TinySDF.prototype.draw = function (char) {
 
     for (i = 0; i < this.size * this.size; i++) {
         var d = this.gridOuter[i] - this.gridInner[i];
-        var c = Math.max(0, Math.min(255, Math.round(255 - 255 * (d / this.radius + this.cutoff))));
-        data[4 * i + 0] = c;
-        data[4 * i + 1] = c;
-        data[4 * i + 2] = c;
-        data[4 * i + 3] = 255;
+        alphaChannel[i] = Math.max(0, Math.min(255, Math.round(255 - 255 * (d / this.radius + this.cutoff))));
     }
 
-    return imgData;
+    return alphaChannel;
 };
 
 // 2D Euclidean distance transform by Felzenszwalb & Huttenlocher https://cs.brown.edu/~pff/dt/

--- a/index.js
+++ b/index.js
@@ -4,11 +4,12 @@ module.exports = TinySDF;
 
 var INF = 1e20;
 
-function TinySDF(fontSize, buffer, radius, cutoff, fontFamily) {
+function TinySDF(fontSize, buffer, radius, cutoff, fontFamily, fontWeight) {
     this.fontSize = fontSize || 24;
     this.buffer = buffer === undefined ? 3 : buffer;
     this.cutoff = cutoff || 0.25;
     this.fontFamily = fontFamily || 'sans-serif';
+    this.fontWeight = fontWeight || 'normal';
     this.radius = radius || 8;
     var size = this.size = this.fontSize + this.buffer * 2;
 
@@ -16,7 +17,8 @@ function TinySDF(fontSize, buffer, radius, cutoff, fontFamily) {
     this.canvas.width = this.canvas.height = size;
 
     this.ctx = this.canvas.getContext('2d');
-    this.ctx.font = fontSize + 'px ' + this.fontFamily;
+    /* style | variant | weight | size/line-height | family */
+    this.ctx.font = 'normal normal ' + this.fontWeight + ' ' + this.fontSize + 'px/normal ' + this.fontFamily;
     this.ctx.textBaseline = 'middle';
     this.ctx.fillStyle = 'black';
 

--- a/index.js
+++ b/index.js
@@ -17,8 +17,7 @@ function TinySDF(fontSize, buffer, radius, cutoff, fontFamily, fontWeight) {
     this.canvas.width = this.canvas.height = size;
 
     this.ctx = this.canvas.getContext('2d');
-    /* style | variant | weight | size/line-height | family */
-    this.ctx.font = 'normal normal ' + this.fontWeight + ' ' + this.fontSize + 'px/normal ' + this.fontFamily;
+    this.ctx.font = this.fontWeight + ' ' + this.fontSize + 'px ' + this.fontFamily;
     this.ctx.textBaseline = 'middle';
     this.ctx.fillStyle = 'black';
 


### PR DESCRIPTION
It's convenient for the demo to use an RGBA `ImageData` for building the texture, but in general I think we'd expect users of TinySDF to work with an alpha-channel-only result since that's the only actual information in the SDF we generate.

I updated the demo to transform the alpha channel into an `ImageData`, and didn't see any noticeable change in performance.