### PR TITLE
Bump package version to 1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/tiny-sdf",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "Browser-side SDF font generator",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
The latest changes aren't backwards compatible, so semver says we should go all the way to version 2, but that felt like overkill.