### PR TITLE
Simplify and optimize distance transform

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,30 +58,31 @@ TinySDF.prototype.draw = function (char) {
 
 // 2D Euclidean squared distance transform by Felzenszwalb & Huttenlocher https://cs.brown.edu/~pff/papers/dt-final.pdf
 function edt(data, width, height, v, z) {
-    for (var x = 0; x < width; x++) edt1d(data, x, width, v, z, height);
-    for (var y = 0; y < height; y++) edt1d(data, y * width, 1, v, z, width);
+    for (var x = 0; x < width; x++) edt1d(data, x, width, height, v, z);
+    for (var y = 0; y < height; y++) edt1d(data, y * width, 1, width, v, z);
 }
 
 // 1D squared distance transform
-function edt1d(data, x, m, v, z, n) {
+function edt1d(data, offset, stride, length, v, z) {
     v[0] = 0;
     z[0] = -INF;
     z[1] = +INF;
 
-    for (var q = 1, k = 0, s = 0; q < n; q++) {
+    for (var q = 1, k = 0, s = 0; q < length; q++) {
         do {
-            var i = v[k];
-            s = (data[x + q * m] - data[x + i * m] + q * q - i * i) / (q - i) / 2;
+            var r = v[k];
+            s = (data[offset + q * stride] - data[offset + r * stride] + q * q - r * r) / (q - r) / 2;
         } while (s <= z[k--]);
+
         k += 2;
         v[k] = q;
         z[k] = s;
         z[k + 1] = +INF;
     }
 
-    for (q = 0, k = 0; q < n; q++) {
+    for (q = 0, k = 0; q < length; q++) {
         while (z[k + 1] < q) k++;
-        i = v[k];
-        data[x + q * m] = (q - i) * (q - i) + data[x + i * m];
+        r = v[k];
+        data[offset + q * stride] = (q - r) * (q - r) + data[offset + r * stride];
     }
 }

--- a/index.js
+++ b/index.js
@@ -70,7 +70,7 @@ function edt1d(data, x, m, v, z, n) {
 
     for (var q = 1, k = 0, s = 0; q < n; q++) {
         do {
-            const i = v[k];
+            var i = v[k];
             s = (data[x + q * m] - data[x + i * m] + q * q - i * i) / (q - i) / 2;
         } while (s <= z[k--]);
         k += 2;
@@ -81,7 +81,7 @@ function edt1d(data, x, m, v, z, n) {
 
     for (q = 0, k = 0; q < n; q++) {
         while (z[k + 1] < q) k++;
-        const i = v[k];
+        i = v[k];
         data[x + q * m] = (q - i) * (q - i) + data[x + i * m];
     }
 }

--- a/index.js
+++ b/index.js
@@ -58,12 +58,12 @@ TinySDF.prototype.draw = function (char) {
 
 // 2D Euclidean squared distance transform by Felzenszwalb & Huttenlocher https://cs.brown.edu/~pff/papers/dt-final.pdf
 function edt(data, width, height, v, z) {
-    for (var x = 0; x < width; x++) edt1d2(data, x, width, v, z, height);
-    for (var y = 0; y < height; y++) edt1d2(data, y * width, 1, v, z, width);
+    for (var x = 0; x < width; x++) edt1d(data, x, width, v, z, height);
+    for (var y = 0; y < height; y++) edt1d(data, y * width, 1, v, z, width);
 }
 
 // 1D squared distance transform
-function edt1d2(data, x, m, v, z, n) {
+function edt1d(data, x, m, v, z, n) {
     v[0] = 0;
     z[0] = -INF;
     z[1] = +INF;

--- a/index.js
+++ b/index.js
@@ -65,14 +65,16 @@ function edt(data, width, height, f, v, z) {
 
 // 1D squared distance transform
 function edt1d(grid, offset, stride, length, f, v, z) {
+    var q, k, s, r;
     v[0] = 0;
     z[0] = -INF;
     z[1] = INF;
+
     for (q = 0; q < length; q++) f[q] = grid[offset + q * stride];
 
-    for (var q = 1, k = 0, s = 0; q < length; q++) {
+    for (q = 1, k = 0, s = 0; q < length; q++) {
         do {
-            var r = v[k];
+            r = v[k];
             s = (f[q] - f[r] + q * q - r * r) / (q - r) / 2;
         } while (s <= z[k--]);
 

--- a/index.js
+++ b/index.js
@@ -25,10 +25,8 @@ function TinySDF(fontSize, buffer, radius, cutoff, fontFamily, fontWeight) {
     // temporary arrays for the distance transform
     this.gridOuter = new Float64Array(size * size);
     this.gridInner = new Float64Array(size * size);
-    this.f = new Float64Array(size);
-    this.d = new Float64Array(size);
     this.z = new Float64Array(size + 1);
-    this.v = new Int16Array(size);
+    this.v = new Uint16Array(size);
 
     // hack around https://bugzilla.mozilla.org/show_bug.cgi?id=737852
     this.middle = Math.round((size / 2) * (navigator.userAgent.indexOf('Gecko/') >= 0 ? 1.2 : 1));
@@ -47,52 +45,35 @@ TinySDF.prototype.draw = function (char) {
         this.gridInner[i] = a === 1 ? INF : a === 0 ? 0 : Math.pow(Math.max(0, a - 0.5), 2);
     }
 
-    edt(this.gridOuter, this.size, this.size, this.f, this.d, this.v, this.z);
-    edt(this.gridInner, this.size, this.size, this.f, this.d, this.v, this.z);
+    edt(this.gridOuter, this.size, this.size, this.v, this.z);
+    edt(this.gridInner, this.size, this.size, this.v, this.z);
 
     for (i = 0; i < this.size * this.size; i++) {
-        var d = this.gridOuter[i] - this.gridInner[i];
+        var d = Math.sqrt(this.gridOuter[i]) - Math.sqrt(this.gridInner[i]);
         alphaChannel[i] = Math.max(0, Math.min(255, Math.round(255 - 255 * (d / this.radius + this.cutoff))));
     }
 
     return alphaChannel;
 };
 
-// 2D Euclidean distance transform by Felzenszwalb & Huttenlocher https://cs.brown.edu/~pff/papers/dt-final.pdf
-function edt(data, width, height, f, d, v, z) {
-    for (var x = 0; x < width; x++) {
-        for (var y = 0; y < height; y++) {
-            f[y] = data[y * width + x];
-        }
-        edt1d(f, d, v, z, height);
-        for (y = 0; y < height; y++) {
-            data[y * width + x] = d[y];
-        }
-    }
-    for (y = 0; y < height; y++) {
-        for (x = 0; x < width; x++) {
-            f[x] = data[y * width + x];
-        }
-        edt1d(f, d, v, z, width);
-        for (x = 0; x < width; x++) {
-            data[y * width + x] = Math.sqrt(d[x]);
-        }
-    }
+// 2D Euclidean squared distance transform by Felzenszwalb & Huttenlocher https://cs.brown.edu/~pff/papers/dt-final.pdf
+function edt(data, width, height, v, z) {
+    for (var x = 0; x < width; x++) edt1d2(data, x, width, v, z, height);
+    for (var y = 0; y < height; y++) edt1d2(data, y * width, 1, v, z, width);
 }
 
 // 1D squared distance transform
-function edt1d(f, d, v, z, n) {
+function edt1d2(data, x, m, v, z, n) {
     v[0] = 0;
     z[0] = -INF;
     z[1] = +INF;
 
-    for (var q = 1, k = 0; q < n; q++) {
-        var s = ((f[q] + q * q) - (f[v[k]] + v[k] * v[k])) / (2 * q - 2 * v[k]);
-        while (s <= z[k]) {
-            k--;
-            s = ((f[q] + q * q) - (f[v[k]] + v[k] * v[k])) / (2 * q - 2 * v[k]);
-        }
-        k++;
+    for (var q = 1, k = 0, s = 0; q < n; q++) {
+        do {
+            const i = v[k];
+            s = (data[x + q * m] - data[x + i * m] + q * q - i * i) / (q - i) / 2;
+        } while (s <= z[k--]);
+        k += 2;
         v[k] = q;
         z[k] = s;
         z[k + 1] = +INF;
@@ -100,6 +81,7 @@ function edt1d(f, d, v, z, n) {
 
     for (q = 0, k = 0; q < n; q++) {
         while (z[k + 1] < q) k++;
-        d[q] = (q - v[k]) * (q - v[k]) + f[v[k]];
+        const i = v[k];
+        data[x + q * m] = (q - i) * (q - i) + data[x + i * m];
     }
 }

--- a/index.js
+++ b/index.js
@@ -71,7 +71,8 @@ function edt1d(data, offset, stride, length, v, z) {
     for (var q = 1, k = 0, s = 0; q < length; q++) {
         do {
             var r = v[k];
-            s = (data[offset + q * stride] - data[offset + r * stride] + q * q - r * r) / (q - r) / 2;
+            var d = data[offset + q * stride] - data[offset + r * stride];
+            s = (d + q * q - r * r) / (q - r) / 2;
         } while (s <= z[k--]);
 
         k += 2;
@@ -83,6 +84,6 @@ function edt1d(data, offset, stride, length, v, z) {
     for (q = 0, k = 0; q < length; q++) {
         while (z[k + 1] < q) k++;
         r = v[k];
-        data[offset + q * stride] = (q - r) * (q - r) + data[offset + r * stride];
+        data[offset + q * stride] = data[offset + r * stride] + (q - r) * (q - r);
     }
 }


### PR DESCRIPTION
Refactor Euclidean distance transform — it now uses 2 less temporary arrays and is generally faster and simpler.