### PR TITLE
Remove extra roundtrips for negative offsets

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,9 +76,9 @@ function edt1d(grid, offset, stride, length, f, v, z) {
         do {
             r = v[k];
             s = (f[q] - f[r] + q * q - r * r) / (q - r) / 2;
-        } while (s <= z[k--]);
+        } while (s <= z[k] && --k > -1);
 
-        k += 2;
+        k++;
         v[k] = q;
         z[k] = s;
         z[k + 1] = INF;


### PR DESCRIPTION
In `edt1d()` `k` can become negative, resulting in extra passes with a comparison against `NaN` when `s` is calculated for an undefined index.