### PR TITLE
Add `drawWithMetrics` method that clips SDF to fit browser-provided TextMetrics

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright © 2016-2017 Mapbox, Inc.
+Copyright © 2016-2021 Mapbox, Inc.
 This code available under the terms of the BSD 2-Clause license.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ from system fonts on the browser using Canvas 2D and
 [Felzenszwalb/Huttenlocher distance transform](https://cs.brown.edu/~pff/papers/dt-final.pdf).
 This is very useful for [rendering text with WebGL](https://www.mapbox.com/blog/text-signed-distance-fields/).
 
-This implementation is based directly on the algorithm published in the Felzenszwalb/Huttenlocher paper, and is not a port of the existing C++ implementation provided by the paper's authors. 
+This implementation is based directly on the algorithm published in the Felzenszwalb/Huttenlocher paper, and is not a port of the existing C++ implementation provided by the paper's authors.
 
 Demo: http://mapbox.github.io/tiny-sdf/
 
@@ -24,4 +24,18 @@ var tinySDFGenerator = new TinySDF(fontsize, buffer, radius, cutoff, fontFamily,
 
 var oneSDF = tinySDFGenerator.draw('泽');
 // returns a Uint8ClampedArray array of alpha values (0–255) for a size x size square grid
+
+// To generate glyphs with variable advances (e.g. non-ideographic glyphs),
+// use `drawWithMetrics`
+var sdfWithMetrics = tinySDFGenerator.drawWithMetrics('A');
+// sdfWithMetrics.data is the same as in `draw`, except the size may be clipped to fit the glyph
+// sdfWithMetrics.metrics contains:
+//  top:        Top alignment: glyph ascent - 'top' = baseline
+//  left:       Currently hardwired to 0
+//  width:      Width of rasterized portion of glyph
+//  height
+//  advance:    Layout advance
+//  sdfWidth:   Width of the returned bitmap, usually but not always width + 2 * buffer
+//  sdfHeight  
+//  fontAscent: Maximum ascent of font from baseline
 ```

--- a/index.js
+++ b/index.js
@@ -12,7 +12,14 @@ function TinySDF(fontSize, buffer, radius, cutoff, fontFamily, fontWeight) {
     this.fontFamily = fontFamily || 'sans-serif';
     this.fontWeight = fontWeight || 'normal';
     this.radius = radius || 8;
+
+    // For backwards compatibility, we honor the implicit contract that the
+    // size of the returned bitmap will be fontSize + buffer * 2
     var size = this.size = this.fontSize + this.buffer * 2;
+    // Glyphs may be slightly larger than their fontSize. The canvas already
+    // has buffer space, but create extra buffer space in the output grid for the
+    // "halo" to extend into (if metric extraction is enabled)
+    var gridSize = size + this.buffer * 2;
 
     this.canvas = document.createElement('canvas');
     this.canvas.width = this.canvas.height = size;
@@ -23,8 +30,8 @@ function TinySDF(fontSize, buffer, radius, cutoff, fontFamily, fontWeight) {
     this.ctx.fillStyle = 'black';
 
     // temporary arrays for the distance transform
-    this.gridOuter = new Float64Array(size * size);
-    this.gridInner = new Float64Array(size * size);
+    this.gridOuter = new Float64Array(gridSize * gridSize);
+    this.gridInner = new Float64Array(gridSize * gridSize);
     this.f = new Float64Array(size);
     this.z = new Float64Array(size + 1);
     this.v = new Uint16Array(size);
@@ -33,28 +40,112 @@ function TinySDF(fontSize, buffer, radius, cutoff, fontFamily, fontWeight) {
     this.middle = Math.round((size / 2) * (navigator.userAgent.indexOf('Gecko/') >= 0 ? 1.2 : 1));
 }
 
+function prepareGrids(imgData, width, height, glyphWidth, glyphHeight, gridOuter, gridInner) {
+    // Initialize grids outside the glyph range to alpha 0
+    gridOuter.fill(INF, 0, width * height);
+    gridInner.fill(0, 0, width * height);
+
+    var offset = (width - glyphWidth) / 2; // This is zero if we're not extracting metrics
+
+    for (var y = 0; y < glyphHeight; y++) {
+        for (var x = 0; x < glyphWidth; x++) {
+            var j = (y + offset) * width + x + offset;
+            var a = imgData.data[4 * (y * glyphWidth + x) + 3] / 255; // alpha value
+            if (a === 1) {
+                gridOuter[j] = 0;
+                gridInner[j] = INF;
+            } else if (a === 0) {
+                gridOuter[j] = INF;
+                gridInner[j] = 0;
+            } else {
+                var b = Math.max(0, 0.5 - a);
+                var c = Math.max(0, a - 0.5);
+                gridOuter[j] = b * b;
+                gridInner[j] = c * c;
+            }
+        }
+    }
+}
+
+function extractAlpha(alphaChannel, width, height, gridOuter, gridInner, radius, cutoff) {
+    for (var i = 0; i < width * height; i++) {
+        var d = Math.sqrt(gridOuter[i]) - Math.sqrt(gridInner[i]);
+        alphaChannel[i] = Math.round(255 - 255 * (d / radius + cutoff));
+    }
+}
+
+TinySDF.prototype._draw = function (char, getMetrics) {
+    var textMetrics = this.ctx.measureText(char);
+    // Older browsers only expose the glyph width
+    // This is enough for basic layout with all glyphs using the same fixed size
+    var advance = textMetrics.width;
+
+    var doubleBuffer = 2 * this.buffer;
+    var width, glyphWidth, height, glyphHeight, top;
+
+    var imgTop, imgLeft;
+    // If the browser supports bounding box metrics, we can generate a smaller
+    // SDF. This is a significant performance win.
+    if (getMetrics && textMetrics.actualBoundingBoxLeft !== undefined) {
+        // The integer/pixel part of the top alignment is encoded in metrics.top
+        // The remainder is implicitly encoded in the rasterization
+        top = Math.floor(textMetrics.actualBoundingBoxAscent) - this.middle;
+        imgTop = Math.max(0, this.middle - Math.ceil(textMetrics.actualBoundingBoxAscent));
+        imgLeft = this.buffer;
+
+        // If the glyph overflows the canvas size, it will be clipped at the
+        // bottom/right
+        glyphWidth = Math.min(this.size,
+            Math.ceil(textMetrics.actualBoundingBoxRight - textMetrics.actualBoundingBoxLeft));
+        glyphHeight = Math.min(this.size - imgTop,
+            Math.ceil(textMetrics.actualBoundingBoxAscent + textMetrics.actualBoundingBoxDescent));
+
+        width = glyphWidth + doubleBuffer;
+        height = glyphHeight + doubleBuffer;
+    } else {
+        width = glyphWidth = this.size;
+        height = glyphHeight = this.size
+        top = 0;
+        imgTop = imgLeft = 0;
+    }
+
+    var imgData;
+    if (glyphWidth && glyphHeight) {
+        this.ctx.clearRect(imgLeft, imgTop, glyphWidth, glyphHeight);
+        this.ctx.fillText(char, this.buffer, this.middle);
+        imgData = this.ctx.getImageData(imgLeft, imgTop, glyphWidth, glyphHeight);
+    }
+
+    var alphaChannel = new Uint8ClampedArray(width * height);
+
+    prepareGrids(imgData, width, height, glyphWidth, glyphHeight, this.gridOuter, this.gridInner);
+
+    edt(this.gridOuter, width, height, this.f, this.v, this.z);
+    edt(this.gridInner, width, height, this.f, this.v, this.z);
+
+    extractAlpha(alphaChannel, width, height, this.gridOuter, this.gridInner, this.radius, this.cutoff);
+
+    return {
+        data: alphaChannel,
+        metrics: {
+            width: glyphWidth,
+            height: glyphHeight,
+            sdfWidth: width,
+            sdfHeight: height,
+            top: top,
+            left: 0,
+            advance: advance,
+            fontAscent: textMetrics.fontBoundingBoxAscent
+        }
+    };
+};
+
 TinySDF.prototype.draw = function (char) {
-    this.ctx.clearRect(0, 0, this.size, this.size);
-    this.ctx.fillText(char, this.buffer, this.middle);
+    return this._draw(char, false).data;
+};
 
-    var imgData = this.ctx.getImageData(0, 0, this.size, this.size);
-    var alphaChannel = new Uint8ClampedArray(this.size * this.size);
-
-    for (var i = 0; i < this.size * this.size; i++) {
-        var a = imgData.data[i * 4 + 3] / 255; // alpha value
-        this.gridOuter[i] = a === 1 ? 0 : a === 0 ? INF : Math.pow(Math.max(0, 0.5 - a), 2);
-        this.gridInner[i] = a === 1 ? INF : a === 0 ? 0 : Math.pow(Math.max(0, a - 0.5), 2);
-    }
-
-    edt(this.gridOuter, this.size, this.size, this.f, this.v, this.z);
-    edt(this.gridInner, this.size, this.size, this.f, this.v, this.z);
-
-    for (i = 0; i < this.size * this.size; i++) {
-        var d = Math.sqrt(this.gridOuter[i]) - Math.sqrt(this.gridInner[i]);
-        alphaChannel[i] = Math.round(255 - 255 * (d / this.radius + this.cutoff));
-    }
-
-    return alphaChannel;
+TinySDF.prototype.drawWithMetrics = function (char) {
+    return this._draw(char, true);
 };
 
 // 2D Euclidean squared distance transform by Felzenszwalb & Huttenlocher https://cs.brown.edu/~pff/papers/dt-final.pdf

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/tiny-sdf",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Browser-side SDF font generator",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Using the canvas TextMetrics capabilities gives TinySDF two benefits:

- `TextMetrics.width` (available in browsers going back to IE9) gives all the information necessary to do text shaping for non-ideographic (variable-advance) glyphs.
- When the bounding box calculations are available on newer browsers, we can trim whitespace out of the SDF, and then adjust the glyph metrics we return to keep the shaping from changing.

cc @mourner