### PR TITLE
Fix glyph width for characters in RTL scripts

### DIFF
--- a/index.js
+++ b/index.js
@@ -95,8 +95,10 @@ TinySDF.prototype._draw = function (char, getMetrics) {
 
         // If the glyph overflows the canvas size, it will be clipped at the
         // bottom/right
+        // Math.abs is necessary because characters from an RTL script will be
+        // laid out in the opposite direction
         glyphWidth = Math.min(this.size,
-            Math.ceil(textMetrics.actualBoundingBoxRight - textMetrics.actualBoundingBoxLeft));
+            Math.ceil(Math.abs(textMetrics.actualBoundingBoxRight - textMetrics.actualBoundingBoxLeft)));
         glyphHeight = Math.min(this.size - imgTop,
             Math.ceil(textMetrics.actualBoundingBoxAscent + textMetrics.actualBoundingBoxDescent));
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/tiny-sdf",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Browser-side SDF font generator",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
`measureText` is not directly measuring glyphs -- it's actually measuring a run of text. When we provide a character from an RTL script, it lays the single-character run of text out right-to-left, and the right of the bounding box ends up being less than the left of the bounding box. TinySDF tries to allocate a negative-size array for the glyph and errors out.

I think there may be more work to do to get the `left` metric correct, but this PR at least avoids the crash and gives something renderable.

@mourner 