### PR TITLE
Force RTL characters to left-alignment

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,6 +27,7 @@ function TinySDF(fontSize, buffer, radius, cutoff, fontFamily, fontWeight) {
     this.ctx = this.canvas.getContext('2d');
     this.ctx.font = this.fontWeight + ' ' + this.fontSize + 'px ' + this.fontFamily;
     this.ctx.textBaseline = 'middle';
+    this.ctx.textAlign = 'left'; // Necessary so that RTL text doesn't have different alignment
     this.ctx.fillStyle = 'black';
 
     // temporary arrays for the distance transform
@@ -95,10 +96,8 @@ TinySDF.prototype._draw = function (char, getMetrics) {
 
         // If the glyph overflows the canvas size, it will be clipped at the
         // bottom/right
-        // Math.abs is necessary because characters from an RTL script will be
-        // laid out in the opposite direction
         glyphWidth = Math.min(this.size,
-            Math.ceil(Math.abs(textMetrics.actualBoundingBoxRight - textMetrics.actualBoundingBoxLeft)));
+            Math.ceil(textMetrics.actualBoundingBoxRight - textMetrics.actualBoundingBoxLeft));
         glyphHeight = Math.min(this.size - imgTop,
             Math.ceil(textMetrics.actualBoundingBoxAscent + textMetrics.actualBoundingBoxDescent));
 


### PR DESCRIPTION
PR #26 prevented crashes on characters from RTL scripts, but could still mis-calculate the glyph width, leading to cut off characters. Poking around in MDN, I realized that the [canvas `textAlign` property](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/textAlign) allows us to force all text to be laid out with left-alignment, which gives us the results the algorithm was expecting in the first place.

**Before**
![Screen Shot 2021-01-26 at 9 39 21](https://user-images.githubusercontent.com/375121/105784210-b11e2d00-5fbb-11eb-8cc1-0155d322578b.png)

**After**
![Screen Shot 2021-01-26 at 9 38 54](https://user-images.githubusercontent.com/375121/105784224-b67b7780-5fbb-11eb-9893-5b394e5e4833.png)

@mourner 