### PR TITLE
Golf some tiny performance improvements

### DIFF
--- a/index.js
+++ b/index.js
@@ -157,17 +157,18 @@ function edt(data, width, height, f, v, z) {
 
 // 1D squared distance transform
 function edt1d(grid, offset, stride, length, f, v, z) {
-    var q, k, s, r;
+    var q, k, s, r, q_sq;
     v[0] = 0;
     z[0] = -INF;
     z[1] = INF;
-
-    for (q = 0; q < length; q++) f[q] = grid[offset + q * stride];
+    f[0] = grid[offset];
 
     for (q = 1, k = 0, s = 0; q < length; q++) {
+        f[q] = grid[offset + q * stride];
+        q_sq = q * q;
         do {
             r = v[k];
-            s = (f[q] - f[r] + q * q - r * r) / (q - r) / 2;
+            s = (f[q] - f[r] + q_sq - r * r) / (q - r) / 2;
         } while (s <= z[k] && --k > -1);
 
         k++;


### PR DESCRIPTION
Made some small changes to `edt1d` that seem to result in savings a few milliseconds on the demo page when locally comparing this branch to `master`:

- Pre-compute `q * q` so it isn't done multiple times in the `do-while` loop. This feels like a very safe change.
- Remove the for-loop that pre-fills `f[q]`, collapsing it into the subsequent loop. I'm a little less sure about this one due to the `f[q] - f[r]` on line 171. It seems to hold that `r < q`, at least for the demo page, but I'm not sure if that is always the case.

Any way, I was just having a little fun. 