### PR TITLE
Fix working array overflow

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,9 +33,9 @@ function TinySDF(fontSize, buffer, radius, cutoff, fontFamily, fontWeight) {
     // temporary arrays for the distance transform
     this.gridOuter = new Float64Array(gridSize * gridSize);
     this.gridInner = new Float64Array(gridSize * gridSize);
-    this.f = new Float64Array(size);
-    this.z = new Float64Array(size + 1);
-    this.v = new Uint16Array(size);
+    this.f = new Float64Array(gridSize);
+    this.z = new Float64Array(gridSize + 1);
+    this.v = new Uint16Array(gridSize);
 
     // hack around https://bugzilla.mozilla.org/show_bug.cgi?id=737852
     this.middle = Math.round((size / 2) * (navigator.userAgent.indexOf('Gecko/') >= 0 ? 1.2 : 1));


### PR DESCRIPTION
When I increased the size of the grid to accommodate halos that could extend outside of the default canvas size, I should have increased the size of the three working arrays to match. Instead, I made it possible for `edt1d` to index past the end of the working arrays, at which point it does a bunch of nonsense math with `NaN` and `undefined` and then assigns the results to non-existent array positions. At the end it doesn't actually copy any undefined values into the output grid, so the very "end" of the grid (the lower right corner of the output) is left at the "alpha 0" state it's initialized to, which happens to be correct for almost any glyph (thus we didn't notice the problem).

However, on Firefox, running this code is dramatically slower. As far as I can tell, the logic is all being evaluated the same way, but since this is the innermost loop of an expensive operation, it's not surprising that small differences in handling out-of-bounds array access could have a big impact.

@mourner