### PR TITLE
Switch to using alphabetic baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,11 @@ var oneSDF = tinySDFGenerator.draw('泽');
 var sdfWithMetrics = tinySDFGenerator.drawWithMetrics('A');
 // sdfWithMetrics.data is the same as in `draw`, except the size may be clipped to fit the glyph
 // sdfWithMetrics.metrics contains:
-//  top:        Top alignment: glyph ascent - 'top' = baseline
-//  left:       Currently hardwired to 0
+//  top:        Maximum ascent of glyph from alphabetic baseline
+//  left:       Currently hardwired to 0 (actual glyph differences are encoded in the rasterization)
 //  width:      Width of rasterized portion of glyph
 //  height
 //  advance:    Layout advance
 //  sdfWidth:   Width of the returned bitmap, usually but not always width + 2 * buffer
-//  sdfHeight  
-//  fontAscent: Maximum ascent of font from baseline
+//  sdfHeight
 ```


### PR DESCRIPTION
The "middle" baseline was convenient for placing the glyph in the middle of the canvas when we didn't know the metrics, but for fonts with especially large ascenders or descenders, the middle baseline could shift significantly compared to the "alphabetic" baseline we'd normally expect. Extracting metrics gives us all the information we need to correctly place the glyph on the canvas even when we're using the alphabetic baseline, so this PR switches to alphabetic whenever metrics are available.

Here's an overlay of the Meiryo and YaHei fonts, showing how the alphabetic baseline matches expectations (Meiryo "broke" earlier assumption because it has a very large font descender):

![Meiryo vs YaHei baselines](https://user-images.githubusercontent.com/375121/107916950-8287e680-6faa-11eb-8af3-3000574fcb4b.png)

The "top" metric now means "distance from alphabetic baseline to top of glyph" which seems pretty intuitive but notably _different_ from what https://github.com/mapbox/sdf-glyph-foundry generates. GL JS can adjust to bring the two metrics mostly into line.

I did some sanity testing of the resulting glyphs and metrics for the legacy "no metrics" pathway, although I don't think the most recent GL JS runs on any browser that will require going down that pathway. It'll be a nice simplification to remove.

Here are some cross browser/font/platform test results (it would be great to figure out a good way to automate this):

*Chrome MacOS Meiryo : Server Arial*
![Chrome MacOS Meiryo : Server Arial](https://user-images.githubusercontent.com/375121/108149666-b41dc080-7116-11eb-82ca-84d03e1166d5.png)
*Chrome macOS Meiryo:Meiryo*
![Chrome macOS Meiryo:Meiryo](https://user-images.githubusercontent.com/375121/108149667-b5e78400-7116-11eb-8a30-f4e83f9a9caf.png)
*Chrome MacOS san-serif all*
![Chrome MacOS san-serif all](https://user-images.githubusercontent.com/375121/108149669-b6801a80-7116-11eb-8047-226995001ac7.png)
*Chrome MacOS sans-serif: server Arial*
![Chrome MacOS sans-serif: server Arial](https://user-images.githubusercontent.com/375121/108149671-b6801a80-7116-11eb-97c2-6eff97ec8ba7.png)
*Chrome Windows 10 : sans-serif all*
![Chrome Windows 10 : sans-serif all](https://user-images.githubusercontent.com/375121/108149673-b718b100-7116-11eb-943d-ad1af5743911.png)
*Chrome Windows 10 sans-serif : Server Arial*
![Chrome Windows 10 sans-serif : Server Arial](https://user-images.githubusercontent.com/375121/108149674-b7b14780-7116-11eb-96d7-12554760b2c7.png)
*Edge Windows 10 sans-serif : Server Arial*
![Edge Windows 10 sans-serif : Server Arial](https://user-images.githubusercontent.com/375121/108149675-b7b14780-7116-11eb-8954-f8bdbda63d8a.png)
*Edge Windows 10 sans-serif all*
![Edge Windows 10 sans-serif all](https://user-images.githubusercontent.com/375121/108149676-b849de00-7116-11eb-95f3-3f66500efb3b.png)
*Firefox MacOS san-serif : Server Arial*
![Firefox MacOS san-serif : Server Arial](https://user-images.githubusercontent.com/375121/108149679-b849de00-7116-11eb-9cdc-4490b4e57722.png)
*Firefox MacOS sans-serif all*
![Firefox MacOS sans-serif all](https://user-images.githubusercontent.com/375121/108149681-b8e27480-7116-11eb-9e0d-f623c710fa66.png)
*Firefox Windows 10 sans-serif : Server Arial Unicode*
![Firefox Windows 10 sans-serif : Server Arial Unicode](https://user-images.githubusercontent.com/375121/108149682-b8e27480-7116-11eb-8e6c-2f341c5c1e27.png)
*Firefox Windows 10 sans-serif all*
![Firefox Windows 10 sans-serif all](https://user-images.githubusercontent.com/375121/108149683-b97b0b00-7116-11eb-9780-5281b86b3c3f.png)

@mourner 