### PR TITLE
Update glyphAdvance type to number

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -18,6 +18,6 @@ export default class TinySDF {
         glyphHeight: number;
         glyphTop: number;
         glyphLeft: number;
-        glyphAdvance: any;
+        glyphAdvance: number;
     };
 }


### PR DESCRIPTION
In the code, this value seems to come from `measureText().width`, which is a `number`.