### PR TITLE
Accepting a lang option and applying it to canvas's ctx.lang

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -6,6 +6,7 @@ export declare type TinySDFOptions = {
     fontFamily?: string;
     fontWeight?: string;
     fontStyle?: string;
+    lang?: string;
 };
 
 export default class TinySDF {

--- a/index.js
+++ b/index.js
@@ -22,7 +22,6 @@ export default class TinySDF {
 
         const canvas = this._createCanvas(size);
         const ctx = this.ctx = canvas.getContext('2d', {willReadFrequently: true});
-        ctx.lang = lang || ctx.lang;
         ctx.font = `${fontStyle} ${fontWeight} ${fontSize}px ${fontFamily}`;
 
         ctx.textBaseline = 'alphabetic';
@@ -70,7 +69,7 @@ export default class TinySDF {
         if (glyphWidth === 0 || glyphHeight === 0) return glyph;
 
         const {ctx, buffer, gridInner, gridOuter} = this;
-        ctx.lang = this.lang || ctx.lang;
+        if (this.lang) ctx.lang = this.lang;
         ctx.clearRect(buffer, buffer, glyphWidth, glyphHeight);
         ctx.fillText(char, buffer, buffer + glyphTop);
         const imgData = ctx.getImageData(buffer, buffer, glyphWidth, glyphHeight);

--- a/index.js
+++ b/index.js
@@ -8,11 +8,13 @@ export default class TinySDF {
         cutoff = 0.25,
         fontFamily = 'sans-serif',
         fontWeight = 'normal',
-        fontStyle = 'normal'
+        fontStyle = 'normal',
+        lang = null
     } = {}) {
         this.buffer = buffer;
         this.cutoff = cutoff;
         this.radius = radius;
+        this.lang = lang;
 
         // make the canvas size big enough to both have the specified buffer around the glyph
         // for "halo", and account for some glyphs possibly being larger than their font size
@@ -20,6 +22,7 @@ export default class TinySDF {
 
         const canvas = this._createCanvas(size);
         const ctx = this.ctx = canvas.getContext('2d', {willReadFrequently: true});
+        ctx.lang = lang || ctx.lang;
         ctx.font = `${fontStyle} ${fontWeight} ${fontSize}px ${fontFamily}`;
 
         ctx.textBaseline = 'alphabetic';
@@ -67,6 +70,7 @@ export default class TinySDF {
         if (glyphWidth === 0 || glyphHeight === 0) return glyph;
 
         const {ctx, buffer, gridInner, gridOuter} = this;
+        ctx.lang = this.lang || ctx.lang;
         ctx.clearRect(buffer, buffer, glyphWidth, glyphHeight);
         ctx.fillText(char, buffer, buffer + glyphTop);
         const imgData = ctx.getImageData(buffer, buffer, glyphWidth, glyphHeight);

--- a/test/test.js
+++ b/test/test.js
@@ -105,3 +105,11 @@ test('does not return negative-width glylphs', () => {
     assert.equal(glyph.glyphWidth, 0);
     assert.equal(glyph.width, 6); // zero-width glyph with 3px buffer
 });
+
+test('renders Simplified and Traditional Chinese', () => {
+    const sdf1 = new MockTinySDF({lang: 'zh'});
+    const glyph1 = sdf1.draw('门');
+    const sdf2 = new MockTinySDF({lang: 'ja'});
+    const glyph2 = sdf2.draw('门');
+    assert.deepStrictEqual(glyph1.data, glyph2.data);
+});

--- a/test/test.js
+++ b/test/test.js
@@ -106,10 +106,12 @@ test('does not return negative-width glylphs', () => {
     assert.equal(glyph.width, 6); // zero-width glyph with 3px buffer
 });
 
-test('renders Simplified and Traditional Chinese', () => {
+/*
+test('renders Chinese and Japanese versions of characters', () => {
     const sdf1 = new MockTinySDF({lang: 'zh'});
     const glyph1 = sdf1.draw('门');
     const sdf2 = new MockTinySDF({lang: 'ja'});
     const glyph2 = sdf2.draw('门');
-    assert.deepStrictEqual(glyph1.data, glyph2.data);
+    assert.notDeepStrictEqual(glyph1.data, glyph2.data);
 });
+*/


### PR DESCRIPTION
In Unicode, codepoints such as 化 may appear as <span lang="zh-Hans">化</span>, <span lang="zh-Hant">化</span>, or <span lang="ja">化</span> depending on the lang tag of the element or page.
While testing the new vector tile layer on OSM, I noticed that switching the UI language between Simplified Chinese, Traditional Chinese, and Japanese updates the map labels in Firefox but not in Chrome. After some testing, I noticed that tiny-sdf has a similar issue in Chrome.

After setting `ctx.lang = "zh-Hant"` or relevant language, Chrome will respect the language tag.
This PR would add `lang` as an option in the constructor as in: `new TinySDF({ lang: 'zh' })`

Testing: I proposed a test, but the issue might exist in Node-Canvas too? I'm getting the same data from the two canvases.