### PR TITLE
Upgrade node-canvas dependency and test

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -15,5 +15,8 @@ jobs:
     - name: Install dependencies
       run: npm ci
 
+    - name: Install CJK font
+      run: wget https://github.com/googlefonts/noto-cjk/raw/main/Sans/OTF/SimplifiedChinese/NotoSansCJKsc-Regular.otf -O /usr/share/fonts/NotoSansCJKsc-Regular.otf && fc-cache -fv
+
     - name: Run tests
       run: npm test

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.0.7",
       "license": "BSD-2-Clause",
       "devDependencies": {
-        "canvas": "3.1.2",
+        "canvas": "^3.2.0",
         "eslint": "^9.32.0",
         "eslint-config-mourner": "^4.1.0",
         "eslint-plugin-html": "^8.1.3",
@@ -469,9 +469,9 @@
       }
     },
     "node_modules/canvas": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/canvas/-/canvas-3.1.2.tgz",
-      "integrity": "sha512-Z/tzFAcBzoCvJlOSlCnoekh1Gu8YMn0J51+UAuXJAbW1Z6I9l2mZgdD7738MepoeeIcUdDtbMnOg6cC7GJxy/g==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/canvas/-/canvas-3.2.0.tgz",
+      "integrity": "sha512-jk0GxrLtUEmW/TmFsk2WghvgHe8B0pxGilqCL21y8lHkPUGa6FTsnCNtHPOzT8O3y+N+m3espawV80bbBlgfTA==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "index.d.ts"
   ],
   "devDependencies": {
-    "canvas": "3.1.2",
+    "canvas": "^3.2.0",
     "eslint": "^9.32.0",
     "eslint-config-mourner": "^4.1.0",
     "eslint-plugin-html": "^8.1.3",

--- a/test/test.js
+++ b/test/test.js
@@ -106,12 +106,10 @@ test('does not return negative-width glylphs', () => {
     assert.equal(glyph.width, 6); // zero-width glyph with 3px buffer
 });
 
-/*
 test('renders Chinese and Japanese versions of characters', () => {
-    const sdf1 = new MockTinySDF({lang: 'zh'});
+    const sdf1 = new MockTinySDF({fontFamily: 'Noto Sans CJK SC', lang: 'zh'});
     const glyph1 = sdf1.draw('门');
-    const sdf2 = new MockTinySDF({lang: 'ja'});
+    const sdf2 = new MockTinySDF({fontFamily: 'Noto Sans CJK SC', lang: 'ja'});
     const glyph2 = sdf2.draw('门');
     assert.notDeepStrictEqual(glyph1.data, glyph2.data);
 });
-*/

--- a/test/test.js
+++ b/test/test.js
@@ -107,6 +107,7 @@ test('does not return negative-width glylphs', () => {
 });
 
 test('renders Chinese and Japanese versions of characters', () => {
+    // assumes Noto Sans CJK SC font is installed
     const sdf1 = new MockTinySDF({fontFamily: 'Noto Sans CJK SC', lang: 'zh'});
     const glyph1 = sdf1.draw('门');
     const sdf2 = new MockTinySDF({fontFamily: 'Noto Sans CJK SC', lang: 'ja'});


### PR DESCRIPTION
- Upgrades serverside node-canvas to latest version (allows setting `ctx.lang`)
- Un-comments Tiny-SDF test comparing Chinese and Japanese versions of a character 门
- Downloads CJK font in GitHub Actions (if this PR passes CI then that's a sign it's working)